### PR TITLE
Improve skills section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,13 +81,15 @@
         }
 
         #skills-content {
-            display: ruby;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
         }
 
         .skill-tag {
-            margin-bottom: 2px;
-            padding: 2px 10px;
-            background: rgba(26, 26, 46, 0.9);
+            margin: 4px;
+            padding: 4px 12px;
+            background: linear-gradient(135deg, rgba(26, 26, 46, 0.9), rgba(0, 212, 255, 0.1));
             color: #00d4ff;
             border: 1px solid #00d4ff;
             border-radius: 10px;
@@ -674,7 +676,7 @@
         .light-mode .lang-btn,
         .light-mode .skill-tag,
         .light-mode .theme-toggle {
-            background: rgba(255, 255, 255, 0.9);
+            background: linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(240, 240, 240, 0.9));
             color: #007bff;
             border-color: #007bff;
         }


### PR DESCRIPTION
## Summary
- switch `#skills-content` to use a flexible row layout with wrapping
- enlarge `.skill-tag` padding/margin and give it a subtle gradient
- keep the light mode variant consistent with the updated styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688397c4344883308d5ea0189fc8c046